### PR TITLE
Comma Bug fix 

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -41,6 +41,6 @@ if __name__ == '__main__':
             'tweepy>=1.9',
             'django-browserid>=0.6',
             'django-missing>=0.1.10',
-            'django-sekizai>=0.5,'
+            'django-sekizai>=0.5'
         ],
     )


### PR DESCRIPTION
Fix for the error

> ```
> error in django-mongo-auth setup command: 'install_requires' must be a string or list of strings containing valid project/version requirement specifiers; Invalid requirement, parse error at "','"
> ```
